### PR TITLE
Update Makevars

### DIFF
--- a/entab-r/src/Makevars
+++ b/entab-r/src/Makevars
@@ -13,6 +13,7 @@ all: C_clean
 $(SHLIB): $(STATLIB)
 
 $(STATLIB):
+	export PATH="$(PATH):$(HOME)/.cargo/bin" && \
 	cargo build --release --manifest-path=../Cargo.toml --target-dir $(TARGET_DIR)
 	mv ./$(LIBDIR)/$(PLATFORM_STATLIB) ./$(STATLIB)
 


### PR DESCRIPTION
I cribbed this line from the extendr package. It seems to obviate the need to manually modify one's .Rprofile with the path to cargo. This seems to fix the issue on both OS X and Windows 10, though I still can't get it to fully install on windows yet b/c of some other issues with the compiler.