### PR TITLE
Create Makevars.win and Makevars.ucrt

### DIFF
--- a/entab-r/src/Makevars.ucrt
+++ b/entab-r/src/Makevars.ucrt
@@ -1,0 +1,8 @@
+# Use GNU toolchain for R >= 4.2
+TOOLCHAIN = stable-gnu
+
+# Rtools42 doesn't have the linker in the location that cargo expects, so we
+# need to overwrite it via configuration.
+CARGO_LINKER = x86_64-w64-mingw32.static.posix-gcc.exe
+
+include Makevars.win

--- a/entab-r/src/Makevars.win
+++ b/entab-r/src/Makevars.win
@@ -1,0 +1,33 @@
+# TARGET = $(subst 64,x86_64,$(subst 32,i686,$(WIN)))-pc-windows-gnu
+TARGET = $(subst 64,x86_64,$(subst 32,i686,$(WIN)))-pc-windows-gnu
+
+# This is provided in Makevars.ucrt for R >= 4.2
+TOOLCHAIN ?= stable-msvc
+
+TARGET_DIR = ../target
+LIBDIR = $(TARGET_DIR)/$(TARGET)/release
+STATLIB = libentab.dll.a
+PKG_LIBS = -L$(LIBDIR) -lentab -lws2_32 -ladvapi32 -luserenv -lbcrypt
+PLATFORM_STATLIB = libentab.dll.a
+
+all: C_clean
+
+$(SHLIB): $(STATLIB)
+
+$(STATLIB):
+	mkdir -p $(TARGET_DIR)/libgcc_mock
+	cd $(TARGET_DIR)/libgcc_mock && \
+		touch gcc_mock.c && \
+		gcc -c gcc_mock.c -o gcc_mock.o && \
+		ar -r libgcc_eh.a gcc_mock.o && \
+		cp libgcc_eh.a libgcc_s.a
+
+	# CARGO_LINKER is provided in Makevars.ucrt for R >= 4.2
+	export PATH="$(PATH):$(HOME)/.cargo/bin" && \
+	export CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER="$(CARGO_LINKER)" && \
+		export LIBRARY_PATH="$${LIBRARY_PATH};$(CURDIR)/$(TARGET_DIR)/libgcc_mock" && \
+		cargo build --target=$(TARGET) --lib --release --manifest-path=../Cargo.toml --target-dir $(TARGET_DIR)
+		mv ./$(LIBDIR)/entab.dll ./libentab.dll
+		
+C_clean:
+	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS) entab/target


### PR DESCRIPTION
The makefiles allow entab to build on Windows 10 (at least on the computer I am testing on). It's possible there's some extraneous stuff in there because I don't totally understand all of it, to be honest. Resolves https://github.com/bovee/entab/issues/37.