### PR TITLE
Fixed OOB error in ReadBuffer::next

### DIFF
--- a/entab/src/buffer.rs
+++ b/entab/src/buffer.rs
@@ -174,6 +174,15 @@ impl<'r> ReadBuffer<'r> {
                 }
             }
         }
+        if self.consumed > self.buffer.len() {
+            let size = self.consumed - consumed;
+            self.consumed = consumed;
+            if !self.refill()? {
+                return Ok(None);
+            }
+            consumed = 0;
+            self.consumed = size;
+        }
         self.record_pos += 1;
         let mut record = T::default();
         T::get(&mut record, &self.buffer[consumed..self.consumed], state)

--- a/entab/src/buffer.rs
+++ b/entab/src/buffer.rs
@@ -174,14 +174,14 @@ impl<'r> ReadBuffer<'r> {
                 }
             }
         }
-                    let size = self.consumed - consumed;
-while self.consumed > self.buffer.len() {
+        let size = self.consumed - consumed;
+        while self.consumed > self.buffer.len() {
             self.consumed = consumed;
             if !self.refill()? {
                 return Ok(None);
             }
-                        self.consumed = size;
-consumed = 0;
+            self.consumed = size;
+            consumed = 0;
         }
         self.record_pos += 1;
         let mut record = T::default();

--- a/entab/src/buffer.rs
+++ b/entab/src/buffer.rs
@@ -95,7 +95,7 @@ impl<'r> ReadBuffer<'r> {
         let mut capacity = buffer.capacity();
         // if we haven't read anything, but we want more data expand the buffer
         if self.consumed == 0 && buffer.len() * 2 > capacity {
-            buffer.reserve(2 * capacity);
+            buffer.reserve(capacity);
             capacity = buffer.capacity();
         };
 

--- a/entab/src/buffer.rs
+++ b/entab/src/buffer.rs
@@ -94,7 +94,7 @@ impl<'r> ReadBuffer<'r> {
 
         let mut capacity = buffer.capacity();
         // if we haven't read anything, but we want more data expand the buffer
-        if self.consumed == 0 {
+        if self.consumed == 0 && buffer.len() * 2 > capacity {
             buffer.reserve(2 * capacity);
             capacity = buffer.capacity();
         };

--- a/entab/src/buffer.rs
+++ b/entab/src/buffer.rs
@@ -174,14 +174,14 @@ impl<'r> ReadBuffer<'r> {
                 }
             }
         }
-        if self.consumed > self.buffer.len() {
-            let size = self.consumed - consumed;
+                    let size = self.consumed - consumed;
+while self.consumed > self.buffer.len() {
             self.consumed = consumed;
             if !self.refill()? {
                 return Ok(None);
             }
-            consumed = 0;
-            self.consumed = size;
+                        self.consumed = size;
+consumed = 0;
         }
         self.record_pos += 1;
         let mut record = T::default();


### PR DESCRIPTION
Currently, many Records' parse functions return true without checking if there is enough space in the buffer. As a result, after a call to T::parse in ReadBuffer::next, self.consumed can be OOB on self.buffer. To fix this, after the call to T::parse, I've added a check for the case, such that it appropriately calls ReadBuffer::refill if required.

The specifc Record that I encountered this issue on was ChemstationArrayRecord.